### PR TITLE
Input validation, enable simple events

### DIFF
--- a/nodes/ecovacs-account.html
+++ b/nodes/ecovacs-account.html
@@ -20,15 +20,15 @@
 
 <script type="text/html" data-template-name="ecovacs-account">
     <div class="form-row">
-        <label for="node-config-input-email"><i class="fa fa-tag"></i> <span data-i18n="ecovacs-account.email.label"></span></label>
+        <label for="node-config-input-email"><i class="fa fa-user-o"></i> <span data-i18n="ecovacs-account.email.label"></span></label>
         <input type="text" id="node-config-input-email" data-i18n="[placeholder]ecovacs-account.email.placeholder">
     </div>
     <div class="form-row">
-        <label for="node-config-input-password"><i class="fa fa-tag"></i> <span data-i18n="ecovacs-account.password.label"></span></label>
+        <label for="node-config-input-password"><i class="fa fa-key"></i> <span data-i18n="ecovacs-account.password.label"></span></label>
         <input type="password" id="node-config-input-password" data-i18n="[placeholder]ecovacs-account.password.placeholder">
     </div>
     <div class="form-row">
-        <label for="node-config-input-countryCode"><i class="fa fa-tag"></i> <span data-i18n="ecovacs-account.countryCode.label"></span></label>
+        <label for="node-config-input-countryCode"><i class="fa fa-globe"></i> <span data-i18n="ecovacs-account.countryCode.label"></span></label>
         <input type="text" id="node-config-input-countryCode" data-i18n="[placeholder]ecovacs-account.countryCode.placeholder">
     </div>
 </script>

--- a/nodes/ecovacs-account.html
+++ b/nodes/ecovacs-account.html
@@ -2,23 +2,38 @@
     RED.nodes.registerType('ecovacs-account', {
         category: 'config',
         defaults: {
-            countryCode: {value: "DE", required: true}
+            countryCode: {
+                required: true,
+                validate: RED.validators.regex(/^[a-zA-Z]{2}$/),
+                value: "DE"
+            },
+            name: {
+                required: false,
+                value: ""
+            }
         },
         credentials: {
             email: {
-                type: "text"
+                required: true,
+                type: "text",
+                validate: (RED.validators.regex(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,3}$/) || RED.validators.regex(/^[a-zA-Z0-9]{8}$/))
             },
             password: {
-                type: "password"
+                type: "password",
+                required: true
             }
         },
         label: function () {
-            return this.mail || "ecovacs-account";
+            return this.name || "ecovacs-account";
         }
     });
 </script>
 
 <script type="text/html" data-template-name="ecovacs-account">
+    <div class="form-row">
+        <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="ecovacs-account.name.label"></span></label>
+        <input type="text" id="node-config-input-name" placeholder="Name">
+    </div>
     <div class="form-row">
         <label for="node-config-input-email"><i class="fa fa-user-o"></i> <span data-i18n="ecovacs-account.email.label"></span></label>
         <input type="text" id="node-config-input-email" data-i18n="[placeholder]ecovacs-account.email.placeholder">

--- a/nodes/ecovacs-account.js
+++ b/nodes/ecovacs-account.js
@@ -1,6 +1,7 @@
 module.exports = function(RED) {
     function EcovacsAccountNode(n) {
         RED.nodes.createNode(this,n);
+        this.name = n.name;
         this.email = this.credentials.email;
         this.password = this.credentials.password;
         this.countryCode = n.countryCode;

--- a/nodes/ecovacs-deebot.html
+++ b/nodes/ecovacs-deebot.html
@@ -5,24 +5,25 @@
         color: '#1E90FF',
         defaults: {
             account: {
-                type: "ecovacs-account",
-                required: true
+                required: true,
+                type: "ecovacs-account"
             },
             name: {
-                value: "Deebot",
-                required: true
+                required: true,
+                value: "Deebot"
             },
             deviceNumber: {
-                value: "0",
-                required: true
+                required: true,
+                validate: RED.validators.regex(/^[0-9]{0,2}$/),
+                value: "0"
             },
             connectOnStartup: {
                 value: false,
                 required: true
             },
             enableSimpleEvents: {
-                value: false,
-                required: true
+                required: true,
+                value: false
             }
         },
         inputs: 1,

--- a/nodes/ecovacs-deebot.html
+++ b/nodes/ecovacs-deebot.html
@@ -19,6 +19,10 @@
             connectOnStartup: {
                 value: false,
                 required: true
+            },
+            enableSimpleEvents: {
+                value: false,
+                required: true
             }
         },
         inputs: 1,
@@ -46,5 +50,9 @@
     <div class="form-row">
         <label for="node-input-connectOnStartup"><i class="fa fa-tag"></i> <span data-i18n="ecovacs-deebot.connectOnStartup.label"></span></label>
         <input type="checkbox" id="node-input-connectOnStartup">
+    </div>
+    <div class="form-row">
+        <label for="node-input-enableSimpleEvents"><i class="fa fa-tag"></i> <span data-i18n="ecovacs-deebot.enableSimpleEvents.label"></span></label>
+        <input type="checkbox" id="node-input-enableSimpleEvents">
     </div>
 </script>

--- a/nodes/ecovacs-deebot.js
+++ b/nodes/ecovacs-deebot.js
@@ -132,6 +132,11 @@ module.exports = function (RED) {
                         const msg = createMsgObject('ContinuousCleaningEnabled', continuousCleaning);
                         node.send(msg);
                     });
+                    node.vacbot.on('VoiceReportDisabled', (value) => {
+                        const voiceReportDisabled = (parseInt(value) === 1);
+                        const msg = createMsgObject('VoiceReportDisabled', voiceReportDisabled);
+                        node.send(msg);
+                    });
                     node.vacbot.on('LastUsedAreaValues', (value) => {
                         const msg = createMsgObject('LastUsedAreaValues', value);
                         node.send(msg);
@@ -160,6 +165,121 @@ module.exports = function (RED) {
                         const msg = createMsgObject('CurrentSpotAreaID', value);
                         node.send(msg);
                     });
+                    node.vacbot.on('RelocationState', (value) => {
+                        const msg = createMsgObject('RelocationState', value);
+                        node.send(msg);
+                    });
+                    // Activate additional simple events if enabled
+                    if (node.config.enableSimpleEvents) {
+                        node.vacbot.on('ChargePosition', (value) => {
+                            const msg = createMsgObject('ChargePosition', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('CleanLog_lastImageTimestamp', (value) => {
+                            const msg = createMsgObject('CleanLog_lastImageTimestamp', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('CleanLog_lastImageUrl', (value) => {
+                            const msg = createMsgObject('CleanLog_lastImageUrl', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('CleanLog_lastSquareMeters', (value) => {
+                            const msg = createMsgObject('CleanLog_lastSquareMeters', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('CleanLog_lastTimestamp', (value) => {
+                            const msg = createMsgObject('CleanLog_lastTimestamp', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('CleanLog_lastTotalTimeString', (value) => {
+                            const msg = createMsgObject('CleanLog_lastTotalTimeString', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('CleanSum_totalNumber', (value) => {
+                            const msg = createMsgObject('CleanSum_totalNumber', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('CleanSum_totalSeconds', (value) => {
+                            const msg = createMsgObject('CleanSum_totalSeconds', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('CleanSum_totalSquareMeters', (value) => {
+                            const msg = createMsgObject('CleanSum_totalSquareMeters', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('DeebotPosition', (value) => {
+                            const msg = createMsgObject('DeebotPosition', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('DeebotPositionIsInvalid', (value) => {
+                            const msg = createMsgObject('DeebotPositionIsInvalid', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('Error', (value) => {
+                            const msg = createMsgObject('Error', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('ErrorCode', (value) => {
+                            const msg = createMsgObject('ErrorCode', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('LifeSpan_filter', (value) => {
+                            const msg = createMsgObject('LifeSpan_filter', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('LifeSpan_main_brush', (value) => {
+                            const msg = createMsgObject('LifeSpan_main_brush', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('LifeSpan_side_brush', (value) => {
+                            const msg = createMsgObject('LifeSpan_side_brush', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('Maps', (object) => {
+                            const msg = createMsgObject('Maps', object);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('MapSpotAreas', (object) => {
+                            const msg = createMsgObject('MapSpotAreas', object);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('MapSpotAreaInfo', (object) => {
+                            const msg = createMsgObject('MapSpotAreaInfo', object);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('MapVirtualBoundaries', (object) => {
+                            const msg = createMsgObject('MapVirtualBoundaries', object);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('MapVirtualBoundaryInfo', (object) => {
+                            const msg = createMsgObject('MapVirtualBoundaryInfo', object);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('NetInfoIP', (value) => {
+                            const msg = createMsgObject('NetInfoIP', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('NetInfoMAC', (value) => {
+                            const msg = createMsgObject('NetInfoMAC', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('NetInfoWifiSignal', (value) => {
+                            const msg = createMsgObject('NetInfoWifiSignal', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('NetInfoWifiSSID', (value) => {
+                            const msg = createMsgObject('NetInfoWifiSSID', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('WaterBoxInfo', (value) => {
+                            const msg = createMsgObject('WaterBoxInfo', value);
+                            node.send(msg);
+                        });
+                        node.vacbot.on('WaterLevel', (value) => {
+                            const msg = createMsgObject('WaterLevel', value);
+                            node.send(msg);
+                        });
+                    }
                 });
                 node.vacbot.connect_and_wait_until_ready();
             });

--- a/nodes/locales/de/ecovacs-account.json
+++ b/nodes/locales/de/ecovacs-account.json
@@ -8,6 +8,9 @@
             "label": "E-Mail-Adresse / Ecovacs ID",
             "placeholder": "E-Mail-Adresse oder ID ihres Ecovacs Kontos"
         },
+        "name": {
+            "label": "Name"
+        },
         "password": {
             "label": "Passwort",
             "placeholder": "Passwort ihres Ecovacs Kontos hier eingeben"

--- a/nodes/locales/de/ecovacs-deebot.json
+++ b/nodes/locales/de/ecovacs-deebot.json
@@ -10,6 +10,9 @@
             "label": "Gerätenummer",
             "placeholder": "Gerätenummer eingeben"
         },
+        "enableSimpleEvents": {
+            "label": "Ausgabe einfache Events aktivieren (zusätzliche zu kombinierten Events)"
+        },
         "name": {
             "label": "Name"
         }

--- a/nodes/locales/en/ecovacs-account.json
+++ b/nodes/locales/en/ecovacs-account.json
@@ -8,6 +8,9 @@
             "label": "Email / Ecovacs ID",
             "placeholder": "Insert email address or ID of your Ecovacs accont"
         },
+        "name": {
+            "label": "Name"
+        },
         "password": {
             "label": "Password",
             "placeholder": "Insert password of your Ecovacs accont"

--- a/nodes/locales/en/ecovacs-deebot.json
+++ b/nodes/locales/en/ecovacs-deebot.json
@@ -10,6 +10,9 @@
             "label": "Device number",
             "placeholder": "Insert number of device here"
         },
+        "enableSimpleEvents": {
+            "label": "Enable output of simple events (additional to combined event output)"
+        },
         "name": {
             "label": "Name"
         }


### PR DESCRIPTION
- Add option to enable simple events, change icons for ecovacs-account fields
- Add basic validation for ecovacs-account (countrycode 2 letters, email or 8 letter/digit user id) and ecovacs-deebot (device number one or two digits)
- Add name entry to ecovacs-account for distinction between accounts as email is now credential and not visible to ecovacs-deebot
- Add event listeners for `VoiceReportDisabled` and `RelocationState`